### PR TITLE
Nuke log statement

### DIFF
--- a/kinesis.go
+++ b/kinesis.go
@@ -122,10 +122,6 @@ func (p *Producer) loop() {
 
 // flush records and retry failures if necessary.
 func (p *Producer) flush(records []*k.PutRecordsRequestEntry, reason string) {
-	p.Logger.WithFields(log.Fields{
-		"records": len(records),
-		"reason":  reason,
-	}).Info("flush")
 
 	out, err := p.Client.PutRecords(&k.PutRecordsInput{
 		StreamName: &p.StreamName,


### PR DESCRIPTION
kinesis stream flush happens a lot and we don't really care. Our log package log level doesn't link in to this package so taking the quick path of removing instead of changing log level.